### PR TITLE
GS-11696

### DIFF
--- a/src/main/java/com/gigaspaces/persistency/MongoSpaceDataSource.java
+++ b/src/main/java/com/gigaspaces/persistency/MongoSpaceDataSource.java
@@ -43,7 +43,7 @@ public class MongoSpaceDataSource extends SpaceDataSource {
 
 	private final MongoClientConnector mongoClient;
 
-    private ClusterInfo clusterInfo;
+	protected ClusterInfo clusterInfo;
 
 	public MongoSpaceDataSource(MongoClientConnector mongoClient, ClusterInfo clusterInfo) {
 


### PR DESCRIPTION
made clusterInfo protected in order to allow users to override getInitialQuery(SpaceTypeDescriptor typeDescriptor) with custom query for each partition
